### PR TITLE
#21 Answer 도메인 객체 생성 시 로직 수정 

### DIFF
--- a/backend/src/main/java/com/example/interviewPrep/quiz/domain/Member.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/domain/Member.java
@@ -15,8 +15,7 @@ import javax.persistence.*;
 @Table(indexes = @Index(name= "i_member", columnList = "email"))
 public class Member {
 
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Id
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name="MEMBER_ID")
     private Long id;
 

--- a/backend/src/main/java/com/example/interviewPrep/quiz/service/AnswerService.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/service/AnswerService.java
@@ -5,6 +5,7 @@ import com.example.interviewPrep.quiz.domain.Answer;
 import com.example.interviewPrep.quiz.domain.Question;
 import com.example.interviewPrep.quiz.dto.AnswerDTO;
 import com.example.interviewPrep.quiz.repository.AnswerRepository;
+import com.example.interviewPrep.quiz.repository.QuestionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -18,6 +19,8 @@ public class AnswerService {
 
     @Autowired
     private final AnswerRepository answerRepository;
+    @Autowired
+    private final QuestionRepository questionRepository;
 
     public List<Answer> createAnswers(List<AnswerDTO> answerDTOs){
 
@@ -25,8 +28,7 @@ public class AnswerService {
 
         for(AnswerDTO answerDTO: answerDTOs){
 
-            Question question = new Question();
-            question.setId(answerDTO.getQuestionId());
+            Question question = questionRepository.findById(answerDTO.getQuestionId());
 
             Answer answer =  Answer.builder()
                     .question(question)


### PR DESCRIPTION
- Answer 도메인 객체 생성 시 
  기존에는 임의의 Question 객체를 생성해서 Answer 도메인 객체에 추가했는데,
  DB에서 questionId로 검색해서 추가하는 것으로 수정했습니다.  