### PR TITLE
#29 OAuth2 google security 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -54,6 +54,12 @@ dependencies {
 	// JSON Object
 	implementation group: 'org.json', name: 'json', version: '20090211'
 
+	//OAuth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	//security-test
+	testImplementation 'org.springframework.security:spring-security-test'
+
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/example/interviewPrep/quiz/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/config/SecurityConfig.java
@@ -1,0 +1,34 @@
+package com.example.interviewPrep.quiz.config;
+
+import com.example.interviewPrep.quiz.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter{
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .headers().frameOptions().disable() // H2 데이터 베이스 콘솔에 접근
+                .and()
+                .authorizeRequests() //url별 권한 접근제어 관리 옵션 시작점
+                .antMatchers("/", "/css/**", "/images/**", "/js/**", "/h2-console/**").permitAll() //권한 관리 대상 지정
+                .anyRequest().authenticated() //나머지 요청들은 인증된 사람에게만 공개( 인증된 사람 == 로그인 사용자)
+                //.anyRequest().permitAll()
+                .and()
+                .logout()
+                .logoutSuccessUrl("/") //로그아웃 성공시 이동
+                .invalidateHttpSession(true) //로그아웃 시 세션 삭제
+                .and()
+                .oauth2Login()//OAuth2 로그인 설정의 진입점
+                .userInfoEndpoint()//로그인 성공 이후 사용자 정보 가져올때의 설정 담당
+                .userService(customOAuth2UserService);
+    }
+}

--- a/backend/src/main/java/com/example/interviewPrep/quiz/controller/IndexController.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/controller/IndexController.java
@@ -1,0 +1,30 @@
+package com.example.interviewPrep.quiz.controller;
+
+import com.example.interviewPrep.quiz.dto.QuestionDTO;
+import com.example.interviewPrep.quiz.dto.SessionUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import javax.servlet.http.HttpSession;
+
+@RequiredArgsConstructor
+@Controller
+public class IndexController{
+
+    private final HttpSession httpSession;
+
+    @GetMapping("/")
+    public String index(Model model) {
+
+
+        SessionUser user = (SessionUser)httpSession.getAttribute("user");
+
+        if(user != null) {
+            model.addAttribute("userName", user.getName());
+        }
+
+        return "index";
+    }
+}

--- a/backend/src/main/java/com/example/interviewPrep/quiz/domain/Member.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/domain/Member.java
@@ -1,12 +1,10 @@
 package com.example.interviewPrep.quiz.domain;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 
+@Setter
 @Entity
 @Getter
 @Builder
@@ -19,7 +17,30 @@ public class Member {
     @Column(name="MEMBER_ID")
     private Long id;
 
+    @Column(nullable = false)
     private String email;
+
     private String password;
+
     private String type;
+
+    private String name;
+
+    @Column
+    private String picture;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    public Member update(String name, String picture){
+        this.name = name;
+        this.picture = picture;
+
+        return this;
+    }
+
+    public String getRoleKey(){
+        return this.role.getKey();
+    }
+
 }

--- a/backend/src/main/java/com/example/interviewPrep/quiz/domain/Role.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/domain/Role.java
@@ -1,0 +1,14 @@
+package com.example.interviewPrep.quiz.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    MENTOR("ROLE_MENTOR", "멘토"),
+    USER("ROLE_USER", "일반 사용자");
+
+    private final String key;
+    private final String title;
+}

--- a/backend/src/main/java/com/example/interviewPrep/quiz/dto/OAuthAttributes.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/dto/OAuthAttributes.java
@@ -1,0 +1,46 @@
+package com.example.interviewPrep.quiz.dto;
+
+import com.example.interviewPrep.quiz.domain.Member;
+import com.example.interviewPrep.quiz.domain.Role;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class OAuthAttributes {
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+    private String picture;
+
+    public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes){
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes){
+        return OAuthAttributes.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .picture((String) attributes.get("picture"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    public Member toEntity(){ // 유저 eneity 생성
+        return Member.builder()
+                .name(name)
+                .email(email)
+                .picture(picture)
+                .role(Role.USER) // 가입 시 기본 권한은 user(일반 사용자)
+                .build();
+    }
+
+
+
+
+
+}

--- a/backend/src/main/java/com/example/interviewPrep/quiz/dto/SessionUser.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/dto/SessionUser.java
@@ -1,0 +1,19 @@
+package com.example.interviewPrep.quiz.dto;
+
+import com.example.interviewPrep.quiz.domain.Member;
+import lombok.Getter;
+
+//인증 된 사용자를 담는 클래스
+
+@Getter
+public class SessionUser  {
+    private String name;
+    private String email;
+    private String picture;
+
+    public SessionUser(Member user) {
+        this.name = user.getName();
+        this.email = user.getEmail();
+        this.picture = user.getPicture();
+    }
+}

--- a/backend/src/main/java/com/example/interviewPrep/quiz/repository/MemberRepository.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/repository/MemberRepository.java
@@ -5,13 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import javax.transaction.Transactional;
-import java.util.List;
+import java.util.Optional;
 
 @Repository
 @Transactional
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    List<Member> findByEmail(String email);
+    Optional<Member> findByEmailAndType(String email, String type);
 
     Member save(Member member);
 

--- a/backend/src/main/java/com/example/interviewPrep/quiz/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/service/CustomOAuth2UserService.java
@@ -1,0 +1,54 @@
+package com.example.interviewPrep.quiz.service;
+
+import com.example.interviewPrep.quiz.domain.Member;
+import com.example.interviewPrep.quiz.dto.OAuthAttributes;
+import com.example.interviewPrep.quiz.dto.SessionUser;
+import com.example.interviewPrep.quiz.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpSession;
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final MemberRepository memberRepository;
+    private final HttpSession httpSession;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest,OAuth2User> delegate = new DefaultOAuth2UserService(); //OAuth2UserService의 구현체
+        OAuth2User oauth2User = delegate.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId(); //로그인 진행 중인 서비스 ex(구글, 카카오)
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+        // OAuth2 로그인 진행 시 키가 되는 필드 값 (== primary key와 같은의미) 구글 기본 코드 ="sub", 네이버, 카카오는 기본 지원x
+
+        OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oauth2User.getAttributes());
+        // OAuth2UserService를 통해 가져온 OAuth2User의 attribute를 담을 클래스
+
+        Member user = saveOrUpdate(attributes, registrationId); //로그인 한 유저 정보
+        httpSession.setAttribute("user", new SessionUser(user)); //세션에 사용자 정보를 저장하기 위한 Dto 클래스
+
+        //로그인 한 유저를 리턴함
+        return new DefaultOAuth2User(Collections.singleton(new SimpleGrantedAuthority(user.getRoleKey())), attributes.getAttributes(), attributes.getNameAttributeKey());
+                                    //단 한개의 객체만 저장 가능한 컬렉션을 만들기 위해 singleton 사용, Granted Authority 를 implement 한 클래스
+    }
+
+    private Member saveOrUpdate(OAuthAttributes attributes, String registrationId){ //이메일로 사용자 찾아 정보를 업뎃, 없으면 유저 등록
+        Member user = memberRepository.findByEmailAndType(attributes.getEmail(), registrationId).map(entity->entity.update(attributes.getName(), attributes.getPicture()))
+                .orElse(attributes.toEntity());
+
+        user.setType(registrationId);
+        return memberRepository.save(user);
+    }
+}

--- a/backend/src/main/java/com/example/interviewPrep/quiz/service/MemberService.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/service/MemberService.java
@@ -21,20 +21,20 @@ public class MemberService {
                 .password(password)
                 .build();
 
-        List<Member> searchedMembers = memberRepository.findByEmail(member.getEmail());
+        Optional<Member> searchedMembers = memberRepository.findByEmailAndType(member.getEmail(),"normal");
 
         if(searchedMembers.isEmpty()){
             return Optional.empty();
         }
-        boolean isSamePassword = PasswordCheck.isMatch(searchedMembers.get(0).getPassword(), password);
+        boolean isSamePassword = PasswordCheck.isMatch(searchedMembers.get().getPassword(), password);
 
         if(!isSamePassword){
             return Optional.empty();
         }
 
         Optional<MemberDTO> searchedMemberDTO = Optional.ofNullable(MemberDTO.builder()
-                .email(searchedMembers.get(0).getEmail())
-                .password(searchedMembers.get(0).getPassword())
+                .email(searchedMembers.get().getEmail())
+                .password(searchedMembers.get().getPassword())
                 .build());
 
         return searchedMemberDTO;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -13,6 +13,9 @@ spring:
         format_sql: true
 #        default_batch_fetch_size: 100
 
+  profiles:
+    include: oauth
+
 logging:
   level:
     org.hibernate.SQL: debug

--- a/backend/src/main/resources/templates/index.html
+++ b/backend/src/main/resources/templates/index.html
@@ -20,6 +20,21 @@
 
     </div>
 
+
+
+    <div class="row">
+        <div class="col-md-10">
+            <div th:if="${not #strings.isEmpty(userName)}">
+                <span id="login-user" th:text="${userName}">사용자</span> 님, 안녕하세요.
+                <a href="/logout" class="btn btn-sm btn-info active" role="button">Logout</a>
+            </div>
+            <div th:if="${#strings.isEmpty(userName)}">
+                <!-- 스프링 시큐리티에서 기본 제공하는 URL - 별도 컨트롤러 작성 필요 없음 -->
+                <a href="/oauth2/authorization/google" class="btn btn-sm btn-success active" role="button">Google Login</a>
+            </div>
+        </div>
+    </div>
+
 </div>
 
 </body>

--- a/backend/src/test/java/com/example/interviewPrep/quiz/Member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/example/interviewPrep/quiz/Member/repository/MemberRepositoryTest.java
@@ -29,6 +29,7 @@ public class MemberRepositoryTest {
     Member member;
     String email;
     String password;
+    String type;
 
     @BeforeEach
     void setUp(){
@@ -36,10 +37,12 @@ public class MemberRepositoryTest {
         // Given
         email = "hello@gmail.com";
         password = "1234";
+        type = "google";
 
         member = Member.builder()
                 .email(email)
                 .password(password)
+                .type(type)
                 .build();
 
     }
@@ -54,11 +57,11 @@ public class MemberRepositoryTest {
 
         // Then
         String savedEmail = member.getEmail();
-        assertEquals(member, memberRepository.findByEmail(savedEmail).get(0));
+        assertEquals(member, memberRepository.findByEmailAndType(savedEmail,type).get());
 
     }
 
-
+    /*
     @Test
     @DisplayName("Email로 회원 찾기")
     public void findByEmail(){
@@ -70,6 +73,8 @@ public class MemberRepositoryTest {
         // Then
         assertThat(email).isEqualTo(searchedMembers.get(0).getEmail());
     }
+
+     */
 
 
 }

--- a/backend/src/test/java/com/example/interviewPrep/quiz/security/IndexWebControllerTest.java
+++ b/backend/src/test/java/com/example/interviewPrep/quiz/security/IndexWebControllerTest.java
@@ -1,0 +1,68 @@
+package com.example.interviewPrep.quiz.security;
+
+import com.example.interviewPrep.quiz.controller.IndexController;
+import com.example.interviewPrep.quiz.service.CustomOAuth2UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/*
+@SpringBootTest 어노테이션은 스프링 부트에서 관리하는 모든 빈들을 생성한 후에 테스트를 실행하기 때문에 테스트에 많은 시간이 소요되며, 단위 테스트에서는 적절하지 않다.
+ @WebMvcTest 어노테이션은 웹과 관련된 빈들만 생성해줘서 비교적 가볍다.
+
+ @MockBeans, @MockBean 을 통해 필요한 빈들을 생성한다.
+@WebMvcTest 에서 테스트에 필요한 모든 빈들을 생성해 주지 않기 때문에 @MockBean 어노테이션을 통해 필요한 빈들을 목업 해줄 수 있다.
+
+MockMvc 클래스를 통해 스프링 MVC의 동작을 재현할 수 있다.
+ */
+@WebMvcTest(IndexController.class) //테스트할 컨트롤러 지정
+public class IndexWebControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    CustomOAuth2UserService customOAuth2UserService;
+
+
+    @Test
+    @DisplayName(" / 처음 화면에서 로그인")
+    void indexPage() throws Exception{
+
+        mockMvc.perform(get("/")
+                .with(oauth2Login()
+                .authorities(new SimpleGrantedAuthority("ROLE_USER"))
+                .attributes(attributes ->{
+                    attributes.put("username", "username");
+                    attributes.put("name", "name");
+                    attributes.put("email", "my@email");
+                    attributes.put("picture", "https://my_picture");
+                })
+                ))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+    }
+
+
+    @Test
+    @DisplayName("인증 하지 않고 다른 url 이동 시 로그인 화면으로 이동")
+    void questionPage() throws Exception{
+
+        mockMvc.perform(get("/question/java"))
+                .andDo(print())
+                .andExpect(status().is3xxRedirection());
+
+    }
+
+}


### PR DESCRIPTION
[security 설정]
- security config 설정 페이지 추가
-  oauth2 service생성 로그인 기능
- 설정파일에서 google profile 추가 (key 값)

[class]
- 사용자 역할 생성 Role(user, mentor)
-  member class에 oauth 클래스 필드 추가(합침)

[controller, 화면]
- "/" 메인 페이지 controller 생성
-  index 화면 구글 로그인 기능 추가

[test]
- security test 생성