### PR TITLE
#41 엔티티 기본 키 생성 전략 수정

### DIFF
--- a/backend/src/main/java/com/example/interviewPrep/quiz/domain/Answer.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/domain/Answer.java
@@ -5,13 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.Lob;
-import javax.persistence.ManyToOne;
+import javax.persistence.*;
 
 import static javax.persistence.FetchType.LAZY;
 
@@ -22,7 +16,7 @@ import static javax.persistence.FetchType.LAZY;
 @AllArgsConstructor
 public class Answer {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "ANSWER_ID")
     private Long id;
 

--- a/backend/src/main/java/com/example/interviewPrep/quiz/domain/Member.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/domain/Member.java
@@ -13,7 +13,7 @@ import javax.persistence.*;
 @Table(indexes = @Index(name= "i_member", columnList = "email"))
 public class Member {
 
-    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="MEMBER_ID")
     private Long id;
 

--- a/backend/src/main/java/com/example/interviewPrep/quiz/domain/Question.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/domain/Question.java
@@ -13,7 +13,7 @@ import javax.persistence.*;
 @Table(indexes = @Index(name= "i_question", columnList = "title"))
 public class Question {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "QUESTION_ID", insertable=false, updatable=false)
     private Long id;
     private String title;


### PR DESCRIPTION

- 엔티티 기본 키 생성 전략 수정
(1) 엔티티 기본 키 생성 전략이 없는 경우 추가하거나,
     기존의 GenerationType.AUTO -> GenerationType.IDENTITY 로 수정하였습니다. 