### PR TITLE
#61 [Feat] 좋아요 동시성이슈 - Optimistic Lock 적용

### DIFF
--- a/backend/src/main/java/com/example/interviewPrep/quiz/domain/Answer.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/domain/Answer.java
@@ -5,7 +5,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.Version;
 
 import static javax.persistence.FetchType.LAZY;
 
@@ -32,8 +40,18 @@ public class Answer {
     @JoinColumn(name = "MEMBER_ID")
     Member member;
 
-    public void change(String content){
+    private int countHeart;
+
+    @Version
+    private Long version;
+
+    public void change(String content) {
         this.content = content;
+    }
+
+    public int increase() {
+        this.countHeart = this.countHeart + 1;
+        return this.countHeart;
     }
 
 }

--- a/backend/src/main/java/com/example/interviewPrep/quiz/infra/JpaAnswerRepository.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/infra/JpaAnswerRepository.java
@@ -4,13 +4,27 @@ import com.example.interviewPrep.quiz.domain.Answer;
 import com.example.interviewPrep.quiz.repository.AnswerRepository;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.LockModeType;
 import java.util.Optional;
 
 @Repository
-@Primary
 public interface JpaAnswerRepository extends AnswerRepository, JpaRepository<Answer, Long> {
     Optional<Answer> findById(Long id);
+
     Answer save(Answer answer);
+
     void delete(Answer answer);
+
+    @Transactional
+    @Lock(value = LockModeType.OPTIMISTIC)
+    @Query("select s from Answer s where s.id = :id")
+    Optional<Answer> findByIdWithOptimisticLock(@Param("id") Long id);
+
+    Answer saveAndFlush(Answer answer);
 }

--- a/backend/src/main/java/com/example/interviewPrep/quiz/repository/AnswerRepository.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/repository/AnswerRepository.java
@@ -1,12 +1,20 @@
 package com.example.interviewPrep.quiz.repository;
 
 import com.example.interviewPrep.quiz.domain.Answer;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface AnswerRepository {
-
     Answer save(Answer answer);
+
     Optional<Answer> findById(Long id);
+
     void delete(Answer answer);
+
+    Optional<Answer> findByIdWithPessimisticLock(@Param("id") Long answerId);
+
+    Optional<Answer> findByIdWithOptimisticLock(@Param("id") Long id);
+
+    Answer saveAndFlush(Answer answer);
 }

--- a/backend/src/main/java/com/example/interviewPrep/quiz/service/HeartService.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/service/HeartService.java
@@ -1,13 +1,14 @@
 package com.example.interviewPrep.quiz.service;
 
 import com.example.interviewPrep.quiz.domain.Answer;
-import com.example.interviewPrep.quiz.repository.AnswerRepository;
 import com.example.interviewPrep.quiz.domain.Heart;
 import com.example.interviewPrep.quiz.exception.AnswerNotFoundException;
 import com.example.interviewPrep.quiz.exception.HeartNotFountException;
+import com.example.interviewPrep.quiz.repository.AnswerRepository;
 import com.example.interviewPrep.quiz.repository.HeartRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +25,8 @@ public class HeartService {
             .answer(answer)
             .build();
 
+        increaseHeartWithOptimisticLock(answer.getId());
+
         heartRepository.save(heart);
         return heart;
     }
@@ -36,5 +39,15 @@ public class HeartService {
         heartRepository.delete(heart);
 
         return heart;
+    }
+
+    @Transactional
+    public void increaseHeartWithOptimisticLock(Long answerId) {
+        Answer answer = answerRepository.findByIdWithOptimisticLock(answerId).orElseThrow(() ->
+            new AnswerNotFoundException("답변 정보를 찾을 수 없어 좋아요를 누를 수 없습니다."));
+
+        answer.increase();
+
+        answerRepository.saveAndFlush(answer);
     }
 }

--- a/backend/src/main/java/com/example/interviewPrep/quiz/service/OptimisticLockHeartFacade.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/service/OptimisticLockHeartFacade.java
@@ -1,0 +1,21 @@
+package com.example.interviewPrep.quiz.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class OptimisticLockHeartFacade {
+    private final HeartService heartService;
+
+    public void increaseHeartWithOptimisticLock(Long answerId) throws InterruptedException {
+        while (true) {
+            try {
+                heartService.increaseHeartWithOptimisticLock(answerId);
+                break;
+            } catch (Exception e) {
+                Thread.sleep(50);
+            }
+        }
+    }
+}

--- a/backend/src/test/java/com/example/interviewPrep/quiz/Heart/service/HeartServiceConcurrencyTest.java
+++ b/backend/src/test/java/com/example/interviewPrep/quiz/Heart/service/HeartServiceConcurrencyTest.java
@@ -1,0 +1,68 @@
+package com.example.interviewPrep.quiz.Heart.service;
+
+import com.example.interviewPrep.quiz.domain.Answer;
+import com.example.interviewPrep.quiz.repository.AnswerRepository;
+import com.example.interviewPrep.quiz.repository.HeartRepository;
+import com.example.interviewPrep.quiz.service.HeartService;
+import com.example.interviewPrep.quiz.service.OptimisticLockHeartFacade;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@Rollback(value = false)
+public class HeartServiceConcurrencyTest {
+    private Logger log = LoggerFactory.getLogger(HeartServiceConcurrencyTest.class);
+    @Autowired
+    AnswerRepository answerRepository;
+    @Autowired
+    HeartRepository heartRepository;
+
+    HeartService heartService;
+
+    @Autowired
+    OptimisticLockHeartFacade optimisticLockHeartFacade;
+
+    Answer answer;
+
+    @BeforeEach
+    void setUp() {
+        answer = Answer.builder()
+            .build();
+        answerRepository.save(answer);
+
+        heartService = new HeartService(heartRepository, answerRepository);
+    }
+
+    @Test
+    void increaseOptimisticLockTest() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    optimisticLockHeartFacade.increaseHeartWithOptimisticLock(answer.getId());
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        assertEquals(100, answerRepository.findById(answer.getId()).orElseThrow().getCountHeart());
+    }
+}


### PR DESCRIPTION
- 문제
  동시에 좋아요가 눌러지는 상황 고려하여 테스트 
  (executorService 라이브러리 사용하여 멀티쓰레드 생성)
  - 32개의 Thread로 100개의 좋아요 생성
<img width="386" alt="스크린샷 2022-10-25 오후 4 11 01" src="https://user-images.githubusercontent.com/38105420/197706938-cf383320-0c04-4e15-8bef-9c5f8edf61d5.png">
  - 해당 문제에 10개 내외의 좋아요 수가 업데이트 되는 것을 확인
- 문제해결
   Optimistic Lock을 활용하여 해결