### PR TITLE
#104 getUserInfo 반환 객체 변경, Member 엔티티에 @JsonIgnore 추가

### DIFF
--- a/backend/src/main/java/com/example/interviewPrep/quiz/member/controller/MemberController.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/member/controller/MemberController.java
@@ -1,19 +1,13 @@
 package com.example.interviewPrep.quiz.member.controller;
 
-
 import com.example.interviewPrep.quiz.member.dto.*;
 import com.example.interviewPrep.quiz.member.service.AuthenticationService;
 import com.example.interviewPrep.quiz.member.service.MemberService;
-import com.example.interviewPrep.quiz.member.social.service.OauthService;
 import com.example.interviewPrep.quiz.response.ResultResponse;
-import com.google.common.net.HttpHeaders;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 

--- a/backend/src/main/java/com/example/interviewPrep/quiz/member/domain/Member.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/member/domain/Member.java
@@ -4,6 +4,7 @@ import com.example.interviewPrep.quiz.answer.domain.Answer;
 import com.example.interviewPrep.quiz.domain.BaseTimeEntity;
 import com.example.interviewPrep.quiz.member.dto.Role;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import lombok.*;
 
@@ -34,6 +35,7 @@ public class Member extends BaseTimeEntity {
 
     private String nickName;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "member")
     private List<Answer> answers = new ArrayList<>();
     private String name;

--- a/backend/src/main/java/com/example/interviewPrep/quiz/member/service/MemberService.java
+++ b/backend/src/main/java/com/example/interviewPrep/quiz/member/service/MemberService.java
@@ -34,7 +34,13 @@ public class MemberService {
 
         Long memberId = Long.parseLong(userDetails.getUsername());
         Member member = memberRepository.findById(memberId).get();
-        return member;
+
+        Member userInfo = Member.builder()
+                          .email(member.getEmail())
+                          .name(member.getName())
+                          .nickName(member.getNickName())
+                          .build();
+        return userInfo;
     }
     public Member changeNickNameAndEmail(MemberDTO memberDTO){
 


### PR DESCRIPTION

- getUserInfo에서 프론트에 반환 시 비밀번호 정보가 없도록 변경하였습니다

- Member 엔티티에 @JsonIgnore를 추가하였습니다