### PR TITLE
#124 Timer AOP 추가

### DIFF
--- a/src/main/java/com/example/interviewPrep/quiz/aop/TimerAop.java
+++ b/src/main/java/com/example/interviewPrep/quiz/aop/TimerAop.java
@@ -1,0 +1,28 @@
+package com.example.interviewPrep.quiz.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+
+@Aspect
+@Component
+public class TimerAop {
+
+    @Pointcut("@annotation(com.example.interviewPrep.quiz.aop.Timer)")//Timer 어노테이션이 붙은 메서드에만 적용
+    private void enableTimer(){}
+
+    @Around("enableTimer()")
+    public void around(ProceedingJoinPoint joinPoint) throws Throwable{ //메서드 실행시 걸린시간 측정
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+
+        Object result = joinPoint.proceed(); //메서드가 실행되는 부분
+
+        stopWatch.stop();
+        System.out.println("total time : "+stopWatch.getTotalTimeSeconds());
+    }
+}

--- a/src/main/java/com/example/interviewPrep/quiz/question/service/QuestionService.java
+++ b/src/main/java/com/example/interviewPrep/quiz/question/service/QuestionService.java
@@ -1,6 +1,7 @@
 package com.example.interviewPrep.quiz.question.service;
 
 import com.example.interviewPrep.quiz.answer.repository.AnswerRepository;
+import com.example.interviewPrep.quiz.aop.Timer;
 import com.example.interviewPrep.quiz.exception.advice.CommonException;
 import com.example.interviewPrep.quiz.question.domain.Question;
 import com.example.interviewPrep.quiz.question.dto.FilterDTO;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -61,9 +63,17 @@ public class QuestionService {
     }
 
 
-    public int getAllQuestionsSize() {
+    public HashMap<String, Integer> getAllQuestionsInfo() {
         List<Question> questions = questionRepository.findAll();
-        return questions.size();
+
+        HashMap<String, Integer> questionInfo = new HashMap<>();
+
+        for(Question question: questions){
+            String type = question.getType();
+            questionInfo.put(type, questionInfo.getOrDefault(type, 0) + 1);
+        }
+
+        return questionInfo;
     }
 
     public Question updateQuestion(Long id, QuestionDTO questionDTO){
@@ -83,6 +93,7 @@ public class QuestionService {
     }
 
     //@Cacheable(value = "questionDTO", key="#pageable.pageSize.toString().concat('-').concat(#pageable.pageNumber)")
+    @Timer
     public Page<QuestionDTO> findByType(String type, Pageable pageable){
         Long memberId = JwtUtil.getMemberId();
         Page<Question> questions;

--- a/src/main/java/com/example/interviewPrep/quiz/question/service/QuestionService.java
+++ b/src/main/java/com/example/interviewPrep/quiz/question/service/QuestionService.java
@@ -93,14 +93,13 @@ public class QuestionService {
     }
 
     //@Cacheable(value = "questionDTO", key="#pageable.pageSize.toString().concat('-').concat(#pageable.pageNumber)")
-    @Timer
+    // @Timer
     public Page<QuestionDTO> findByType(String type, Pageable pageable){
         Long memberId = JwtUtil.getMemberId();
         Page<Question> questions;
 
         if(type==null) questions = questionRepository.findAllBy(pageable);
         else questions = questionRepository.findByType(type, pageable); //문제 타입과 페이지 조건 값을 보내어 question 조회, 반환값 page
-
         if(questions.getContent().isEmpty()) throw new CommonException(NOT_FOUND_QUESTION);
 
         if(memberId==0L){
@@ -115,6 +114,7 @@ public class QuestionService {
     }
 
     public Page<QuestionDTO> makeQuestionDto(Page<Question> questions, List<Long> myAnswer){
+
         return questions.map(q -> QuestionDTO.builder()
                         .id(q.getId())
                         .type(q.getType())


### PR DESCRIPTION

# 문제 정의 및 실행한 작업 

- 문제 데이터의 로딩이 느리다는 문제를 해결하기 위해서 메소드 성능 측정을 위한 AOP를 추가했습니다.  

- QuestionService 클래스의 findByType 메소드의 성능 측정을 위해 TimerAop 클래스를 추가하고,
   @Timer 어노테이션을 findByType 메소드에 추가했습니다.
   (기존에 Timer 인터페이스는 존재했었습니다) 

- 로컬에서 이 메소드의 성능 측정 시 처음 로딩할 때는 0.2초, 이후 로딩 때는 0.02초 정도 걸리는 것으로 확인되었습니다. 
-> 단, 로컬에서는 문제 데이터 수가 적기 때문에, 배포해서 테스트해보아야 제대로 테스트 될 것으로 생각했습니다. 


# 가설 수립 

- 서버에서 로딩이 지연되는 이유는 2가지 정도 원인으로 분석했습니다.
  (1) 문제들을 로딩할 때, 로그인한 사용자가 푼 문제인지를 확인하기 위해, Answer 테이블에 추가적인 쿼리를 보냅니다.
   -> 이 쿼리의 성능이 좋지 않기 때문에 로딩이 지연될 수 있다고 판단했습니다. 
  (2) 현재 프론트와 서버가 AWS의 다른 Region에 있는 다른 인스턴스에 배포 되어 있습니다.
   -> 이로 인해 프론트에서 서버로 요청을 하고 응답을 받는데에 시간이 오래 걸리게 되었을 수 있다고 판단했습니다.


# 추가 계획

- (1) 우선, 현재 코드를 배포하고, 배포된 버전에서 메소드의 성능 측정을 해봐야 할 것으로 생각했습니다.
    -> 만약, 메소드의 성능이 좋지 않다면, 쿼리에 대한 수정이 필요할 것입니다.

   (2) 그 다음 메소드의 성능에 문제가 없다면, 프론트의 배포 인스턴스를 서버와 동일한 인스턴스로 교체하는
        작업을 진행해볼 예정입니다 .

